### PR TITLE
Split sccp_config_addButton function into two parts (v2)

### DIFF
--- a/src/sccp_channel.c
+++ b/src/sccp_channel.c
@@ -1343,6 +1343,13 @@ void sccp_channel_endcall(sccp_channel_t * channel)
  *
  * \param l SCCP Line that owns this channel
  * \param device SCCP Device that owns this channel
+ * \param dial Dialed Number as char
+ * \param calltype Calltype as int
+ * \param parentChannel SCCP Channel for which the channel was created
+ * \return a *retained* SCCP Channel or NULL if something is wrong
+ *
+ * \callgraph
+ * \callergraph
  * 
  */
 //static sccp_channel_t *_sccp_channel_allocate_newcall_helper(const sccp_line_t * l, const sccp_device_t * device)
@@ -1384,6 +1391,16 @@ static sccp_channel_t *_sccp_channel_allocate_newcall_helper(sccp_line_t * l, sc
 
 /*!
  * \brief Helper to Start Dialing newly allocated Channel.
+ *
+ * \param l SCCP Line that owns this channel
+ * \param device SCCP Device that owns this channel
+ * \param dial Dialed Number as char
+ * \param calltype Calltype as int
+ * \param parentChannel SCCP Channel for which the channel was created
+ * \return a *retained* SCCP Channel or NULL if something is wrong
+ *
+ * \callgraph
+ * \callergraph
  * 
  */
 //static sccp_channel_t *_sccp_channel_finish_newcall_helper(const sccp_line_t * l, const sccp_device_t * device, sccp_channel_t *channel, const char *dial, uint8_t calltype, PBX_CHANNEL_TYPE * parentChannel, const void *ids, boolean_t skip_softswitch)
@@ -1434,6 +1451,12 @@ static sccp_channel_t *_sccp_channel_finish_newcall_helper(sccp_line_t * l, sccp
 
 /*!
  * \brief Allocate a new Outgoing Feature Channel.
+ *
+ * \param l SCCP Line that owns this channel
+ * \param device SCCP Device that owns this channel
+ * \param dial Dialed Number as char
+ * \param calltype Calltype as int
+ * \param parentChannel SCCP Channel for which the channel was created
  * \return a *retained* SCCP Channel or NULL if something is wrong
  */
 sccp_channel_t *sccp_channel_new_feature_call(sccp_line_t * l, sccp_device_t * device, sccp_feature_type_t feature, PBX_CHANNEL_TYPE * parentChannel, const void *ids)
@@ -1464,6 +1487,12 @@ sccp_channel_t *sccp_channel_new_feature_call(sccp_line_t * l, sccp_device_t * d
 }
 /*!
  * \brief Allocate a new Outgoing Channel.
+ *
+ * \param l SCCP Line that owns this channel
+ * \param device SCCP Device that owns this channel
+ * \param dial Dialed Number as char
+ * \param calltype Calltype as int
+ * \param parentChannel SCCP Channel for which the channel was created
  * \return a *retained* SCCP Channel or NULL if something is wrong
  * 
  */

--- a/src/sccp_channel.c
+++ b/src/sccp_channel.c
@@ -1343,13 +1343,6 @@ void sccp_channel_endcall(sccp_channel_t * channel)
  *
  * \param l SCCP Line that owns this channel
  * \param device SCCP Device that owns this channel
- * \param dial Dialed Number as char
- * \param calltype Calltype as int
- * \param parentChannel SCCP Channel for which the channel was created
- * \return a *retained* SCCP Channel or NULL if something is wrong
- *
- * \callgraph
- * \callergraph
  * 
  */
 //static sccp_channel_t *_sccp_channel_allocate_newcall_helper(const sccp_line_t * l, const sccp_device_t * device)
@@ -1391,16 +1384,6 @@ static sccp_channel_t *_sccp_channel_allocate_newcall_helper(sccp_line_t * l, sc
 
 /*!
  * \brief Helper to Start Dialing newly allocated Channel.
- *
- * \param l SCCP Line that owns this channel
- * \param device SCCP Device that owns this channel
- * \param dial Dialed Number as char
- * \param calltype Calltype as int
- * \param parentChannel SCCP Channel for which the channel was created
- * \return a *retained* SCCP Channel or NULL if something is wrong
- *
- * \callgraph
- * \callergraph
  * 
  */
 //static sccp_channel_t *_sccp_channel_finish_newcall_helper(const sccp_line_t * l, const sccp_device_t * device, sccp_channel_t *channel, const char *dial, uint8_t calltype, PBX_CHANNEL_TYPE * parentChannel, const void *ids, boolean_t skip_softswitch)
@@ -1451,12 +1434,6 @@ static sccp_channel_t *_sccp_channel_finish_newcall_helper(sccp_line_t * l, sccp
 
 /*!
  * \brief Allocate a new Outgoing Feature Channel.
- *
- * \param l SCCP Line that owns this channel
- * \param device SCCP Device that owns this channel
- * \param dial Dialed Number as char
- * \param calltype Calltype as int
- * \param parentChannel SCCP Channel for which the channel was created
  * \return a *retained* SCCP Channel or NULL if something is wrong
  */
 sccp_channel_t *sccp_channel_new_feature_call(sccp_line_t * l, sccp_device_t * device, sccp_feature_type_t feature, PBX_CHANNEL_TYPE * parentChannel, const void *ids)
@@ -1487,12 +1464,6 @@ sccp_channel_t *sccp_channel_new_feature_call(sccp_line_t * l, sccp_device_t * d
 }
 /*!
  * \brief Allocate a new Outgoing Channel.
- *
- * \param l SCCP Line that owns this channel
- * \param device SCCP Device that owns this channel
- * \param dial Dialed Number as char
- * \param calltype Calltype as int
- * \param parentChannel SCCP Channel for which the channel was created
  * \return a *retained* SCCP Channel or NULL if something is wrong
  * 
  */

--- a/src/sccp_channel.h
+++ b/src/sccp_channel.h
@@ -9,8 +9,8 @@
  * \note        This program is free software and may be modified and distributed under the terms of the GNU Public License.
  *              See the LICENSE file at the top of the source tree.
  *
- * $Date$
- * $Revision$  
+ * $Date: 2015-01-26 17:11:20 +0100 (ma, 26 jan 2015) $
+ * $Revision: 5889 $  
  */
 
 #ifndef __SCCP_CHANNEL_H
@@ -22,6 +22,7 @@
 
 /* live cycle */
 sccp_channel_t *sccp_channel_allocate(sccp_line_t * l, sccp_device_t * device);					// device is optional
+sccp_channel_t *sccp_channel_new_feature_call(sccp_line_t * l, sccp_device_t * device, sccp_feature_type_t feature, PBX_CHANNEL_TYPE * parentChannel, const void *ids);
 sccp_channel_t *sccp_channel_newcall(sccp_line_t * l, sccp_device_t * device, const char *dial, uint8_t calltype, PBX_CHANNEL_TYPE * parentChannel, const void *ids);
 
 void sccp_channel_updateChannelDesignator(sccp_channel_t * c);

--- a/src/sccp_cli.c
+++ b/src/sccp_cli.c
@@ -2826,7 +2826,7 @@ static int sccp_cli_reload(int fd, int argc, char *argv[])
 				int buflen;
 				if (argv[3][0] != '/') { 
 					buflen = strlen(ast_config_AST_CONFIG_DIR) + strlen(argv[3]) + 2;
-					buf = ast_alloca(buflen);
+					buf = alloca(buflen);
 					snprintf(buf, buflen, "%s/%s", ast_config_AST_CONFIG_DIR, argv[3]);
 				} else {
 					buf = strdupa(argv[3]);

--- a/src/sccp_cli.c
+++ b/src/sccp_cli.c
@@ -8,8 +8,8 @@
  * \note        This program is free software and may be modified and distributed under the terms of the GNU Public License.
  *              See the LICENSE file at the top of the source tree.
  *
- * $Date$
- * $Revision$
+ * $Date: 2015-01-27 04:12:36 +0100 (di, 27 jan 2015) $
+ * $Revision: 5890 $
  */
 
 /*!
@@ -62,7 +62,7 @@
 #include "sccp_hint.h"
 #include "sys/stat.h"
 
-SCCP_FILE_VERSION(__FILE__, "$Revision$");
+SCCP_FILE_VERSION(__FILE__, "$Revision: 5890 $");
 #include <asterisk/cli.h>
 typedef enum sccp_cli_completer {
 	SCCP_CLI_NULL_COMPLETER,
@@ -2717,7 +2717,8 @@ static int sccp_cli_reload(int fd, int argc, char *argv[])
 					pbx_cli(fd, "%s: device has %s\n", device->id, change ? "major changes -> restarting device" : "no major changes -> restart not required");
 					if (change == SCCP_CONFIG_NEEDDEVICERESET) {
 						device->pendingUpdate = 1;
-						sccp_device_sendReset(device, SKINNY_DEVICE_RESTART);		// SKINNY_DEVICE_RELOAD_CONFIG
+						sccp_device_check_update(device);				// Will cleanup and Reset
+						//sccp_device_sendReset(device, SKINNY_DEVICE_RESTART);		// SKINNY_DEVICE_RELOAD_CONFIG
 					}
 #ifdef CS_SCCP_REALTIME
 					if (device->realtime) {
@@ -2787,7 +2788,8 @@ static int sccp_cli_reload(int fd, int argc, char *argv[])
 									change = sccp_config_applyDeviceConfiguration(device, v);
 								}
 								device->pendingUpdate = 1;
-								sccp_device_sendReset(device, SKINNY_DEVICE_RESTART);	// SKINNY_DEVICE_RELOAD_CONFIG
+								sccp_device_check_update(device);				// Will cleanup and Reset
+								//sccp_device_sendReset(device, SKINNY_DEVICE_RESTART);	// SKINNY_DEVICE_RELOAD_CONFIG
 #ifdef CS_SCCP_REALTIME
 								if (device->realtime && dv) {
 									pbx_variables_destroy(dv);

--- a/src/sccp_cli.c
+++ b/src/sccp_cli.c
@@ -63,8 +63,9 @@
 #include "sys/stat.h"
 
 SCCP_FILE_VERSION(__FILE__, "$Revision: 5890 $");
-#include <asterisk/paths.h>
+
 #include <asterisk/cli.h>
+#include <asterisk/paths.h>
 typedef enum sccp_cli_completer {
 	SCCP_CLI_NULL_COMPLETER,
 	SCCP_CLI_DEVICE_COMPLETER,

--- a/src/sccp_cli.c
+++ b/src/sccp_cli.c
@@ -2829,7 +2829,7 @@ static int sccp_cli_reload(int fd, int argc, char *argv[])
 					buf = ast_alloca(buflen);
 					snprintf(buf, buflen, "%s/%s", ast_config_AST_CONFIG_DIR, argv[3]);
 				} else {
-					buf = strdupa(buf);
+					buf = strdupa(argv[3]);
 				}
 				// check file exists
 				struct stat sb = { 0 };
@@ -2840,13 +2840,13 @@ static int sccp_cli_reload(int fd, int argc, char *argv[])
 
 				// load new config file
 				pbx_cli(fd, "Using config file '%s' (previous config file: '%s')\n", argv[3], GLOB(config_file_name));
-				if (!sccp_strequals(GLOB(config_file_name), argv[3])) {
+				if (!sccp_strequals(GLOB(config_file_name), buf)) {
 					force_reload = TRUE;
 				}
 				if (GLOB(config_file_name)) {
 					sccp_free(GLOB(config_file_name));
 				}
-				GLOB(config_file_name) = sccp_strdup(argv[3]);
+				GLOB(config_file_name) = sccp_strdup(buf);
 			} else {
 				pbx_cli(fd, "Usage: sccp reload file [filename], filename is required\n");
 				goto EXIT;

--- a/src/sccp_config.c
+++ b/src/sccp_config.c
@@ -1687,11 +1687,18 @@ sccp_value_changed_t sccp_config_parse_button(void *dest, const size_t size, PBX
 			changed = SCCP_CONFIG_CHANGE_CHANGED;
 		}
 
-		/* Nothing Changed: Clear pending Delete and Pending Update */
+		sccp_log((DEBUGCAT_CORE)) (VERBOSE_PREFIX_3 "Number of Buttons changed (%d). Reloading all of them.\n", changed);
+		
+		/* Clear/Set pendingDelete and PendingUpdate if button has changed or not
+		 *
+		 * \note Moved here from device_post_reload so that we will know the new state before line_post_reload. 
+		 * That way adding/removind a line while accidentally keeping the button config for that line still works.
+		 */
 		SCCP_LIST_LOCK(buttonconfigList);
 		SCCP_LIST_TRAVERSE(buttonconfigList, config, list) {
-			config->pendingDelete = SCCP_CONFIG_CHANGE_CHANGED;
+			config->pendingDelete = changed;
 			config->pendingUpdate = 0;
+			sccp_log((DEBUGCAT_CORE)) (VERBOSE_PREFIX_3 "Number of Buttons changed (%d). pendingDelete: %s, pendingUpdate: %s\n", changed, config->pendingDelete ? "on": "off", config->pendingUpdate? "on": "off");
 		}
 		SCCP_LIST_UNLOCK(buttonconfigList);
 	}

--- a/src/sccp_config.c
+++ b/src/sccp_config.c
@@ -816,7 +816,7 @@ void sccp_config_cleanup_dynamically_allocated_memory(void *obj, const sccp_conf
 			dst = ((uint8_t *) obj) + sccpConfigOption[i].offset;
 			str = *(void **) dst;
 			if (str) {
-				//pbx_log(LOG_NOTICE, "SCCP: Freeing '%s'\n", sccpConfigOption[i].name);
+				//pbx_log(LOG_NOTICE, "SCCP: Freeing %s='%s'\n", sccpConfigOption[i].name, str);
 				sccp_free(str);
 				str = NULL;
 			}
@@ -1686,9 +1686,6 @@ sccp_value_changed_t sccp_config_parse_button(void *dest, const size_t size, PBX
 			sccp_log((DEBUGCAT_CONFIG + DEBUGCAT_HIGH)) (VERBOSE_PREFIX_3 "Number of Buttons changed (%d != %d). Reloading all of them.\n", SCCP_LIST_GETSIZE(buttonconfigList), buttonindex);
 			changed = SCCP_CONFIG_CHANGE_CHANGED;
 		}
-
-		sccp_log((DEBUGCAT_CORE)) (VERBOSE_PREFIX_3 "Number of Buttons changed (%d). Reloading all of them.\n", changed);
-		
 		/* Clear/Set pendingDelete and PendingUpdate if button has changed or not
 		 *
 		 * \note Moved here from device_post_reload so that we will know the new state before line_post_reload. 
@@ -1698,7 +1695,6 @@ sccp_value_changed_t sccp_config_parse_button(void *dest, const size_t size, PBX
 		SCCP_LIST_TRAVERSE(buttonconfigList, config, list) {
 			config->pendingDelete = changed;
 			config->pendingUpdate = 0;
-			sccp_log((DEBUGCAT_CORE)) (VERBOSE_PREFIX_3 "Number of Buttons changed (%d). pendingDelete: %s, pendingUpdate: %s\n", changed, config->pendingDelete ? "on": "off", config->pendingUpdate? "on": "off");
 		}
 		SCCP_LIST_UNLOCK(buttonconfigList);
 	}

--- a/src/sccp_config.c
+++ b/src/sccp_config.c
@@ -816,7 +816,7 @@ void sccp_config_cleanup_dynamically_allocated_memory(void *obj, const sccp_conf
 			dst = ((uint8_t *) obj) + sccpConfigOption[i].offset;
 			str = *(void **) dst;
 			if (str) {
-				//pbx_log(LOG_NOTICE, "SCCP: Freeing %s='%s'\n", sccpConfigOption[i].name, str);
+				pbx_log(LOG_NOTICE, "SCCP: Freeing %s='%s'\n", sccpConfigOption[i].name, str);
 				sccp_free(str);
 				str = NULL;
 			}
@@ -1693,7 +1693,7 @@ sccp_value_changed_t sccp_config_parse_button(void *dest, const size_t size, PBX
 		 */
 		SCCP_LIST_LOCK(buttonconfigList);
 		SCCP_LIST_TRAVERSE(buttonconfigList, config, list) {
-			config->pendingDelete = changed;
+			config->pendingDelete = (int)changed;
 			config->pendingUpdate = 0;
 		}
 		SCCP_LIST_UNLOCK(buttonconfigList);
@@ -2018,6 +2018,7 @@ static void sccp_config_buildDevice(sccp_device_t * d, PBX_VARIABLE_TYPE * varia
 		}
 	}
 	SCCP_LIST_UNLOCK(&d->buttonconfig);
+
 #endif
 
 #ifdef CS_SCCP_REALTIME
@@ -2442,7 +2443,6 @@ sccp_configurationchange_t sccp_config_applyDeviceConfiguration(sccp_device_t * 
 	if (d->keepalive < SCCP_MIN_KEEPALIVE) {
 		d->keepalive = SCCP_MIN_KEEPALIVE;
 	}
-
 	return res;
 }
 
@@ -2727,7 +2727,6 @@ void sccp_config_restoreDeviceFeatureStatus(sccp_device_t * device)
 #ifndef ASTDB_RESULT_LEN
 #define ASTDB_RESULT_LEN 256
 #endif
-
 	char buffer[ASTDB_RESULT_LEN];
 	char timebuffer[ASTDB_RESULT_LEN];
 	int timeout = 0;

--- a/src/sccp_config.c
+++ b/src/sccp_config.c
@@ -1691,12 +1691,14 @@ sccp_value_changed_t sccp_config_parse_button(void *dest, const size_t size, PBX
 		 * \note Moved here from device_post_reload so that we will know the new state before line_post_reload. 
 		 * That way adding/removind a line while accidentally keeping the button config for that line still works.
 		 */
-		SCCP_LIST_LOCK(buttonconfigList);
-		SCCP_LIST_TRAVERSE(buttonconfigList, config, list) {
-			config->pendingDelete = (int)changed;
-			config->pendingUpdate = 0;
+		if (!changed) {
+			SCCP_LIST_LOCK(buttonconfigList);
+			SCCP_LIST_TRAVERSE(buttonconfigList, config, list) {
+				config->pendingDelete = 0;
+				config->pendingUpdate = 0;
+			}
+			SCCP_LIST_UNLOCK(buttonconfigList);
 		}
-		SCCP_LIST_UNLOCK(buttonconfigList);
 	}
 	if (changed) {
 		buttonindex = 0;										/* buttonconfig has changed. Load all buttons as new ones */

--- a/src/sccp_device.c
+++ b/src/sccp_device.c
@@ -1911,28 +1911,7 @@ void sccp_dev_clean(sccp_device_t * device, boolean_t remove_from_global, uint8_
 			PBX(feature_addToDatabase) (family, "lastDialedNumber", d->lastNumber);
 		}
 
-		/* cleanup dynamic allocated strings */
-
-		/** normaly we should only remove this when removing the device from globals,
-		 *  in this case we can do this also when device unregistered, so we do not set this multiple times -MC
-		 */
-		/*
-		if (d->backgroundImage) {
-			sccp_free(d->backgroundImage);
-			d->backgroundImage = NULL;
-		}
-		*/
-
-		/*
-		if (d->ringtone) {
-			sccp_free(d->ringtone);
-			d->ringtone = NULL;
-		}
-		*/
-		sccp_config_cleanup_dynamically_allocated_memory(d, SCCP_CONFIG_DEVICE_SEGMENT);
-
 		/* hang up open channels and remove device from line */
-
 		SCCP_LIST_LOCK(&d->buttonconfig);
 		SCCP_LIST_TRAVERSE_SAFE_BEGIN(&d->buttonconfig, config, list) {
 			if (config->type == LINE) {
@@ -2063,6 +2042,9 @@ int __sccp_device_destroy(const void *ptr)
 	}
 
 	sccp_log((DEBUGCAT_DEVICE + DEBUGCAT_CONFIG)) (VERBOSE_PREFIX_1 "%s: Destroying Device\n", d->id);
+
+	/* cleanup dynamic allocated during sccp_config (i.e. STRINGPTR) */
+	sccp_config_cleanup_dynamically_allocated_memory(d, SCCP_CONFIG_DEVICE_SEGMENT);
 
 	/* remove button config */
 	/* only generated on read config, so do not remove on reset/restart */

--- a/src/sccp_device.c
+++ b/src/sccp_device.c
@@ -290,6 +290,7 @@ static boolean_t sccp_device_checkACL(sccp_device_t * device)
 void sccp_device_pre_reload(void)
 {
 	sccp_device_t *d;
+	sccp_buttonconfig_t *config;
 
 	SCCP_RWLIST_WRLOCK(&GLOB(devices));
 	SCCP_RWLIST_TRAVERSE(&GLOB(devices), d, list) {
@@ -298,6 +299,12 @@ void sccp_device_pre_reload(void)
 			d->pendingDelete = 1;
 		}
 		d->pendingUpdate = 0;
+		SCCP_LIST_LOCK(&d->buttonconfig);
+		SCCP_LIST_TRAVERSE(&d->buttonconfig, config, list) {
+			config->pendingDelete = 1;
+			config->pendingUpdate = 0;
+		}
+		SCCP_LIST_UNLOCK(&d->buttonconfig);
 	}
 	SCCP_RWLIST_UNLOCK(&GLOB(devices));
 }

--- a/src/sccp_device.c
+++ b/src/sccp_device.c
@@ -301,6 +301,7 @@ void sccp_device_pre_reload(void)
 		d->pendingUpdate = 0;
 		SCCP_LIST_LOCK(&d->buttonconfig);
 		SCCP_LIST_TRAVERSE(&d->buttonconfig, config, list) {
+			sccp_log((DEBUGCAT_CONFIG + DEBUGCAT_DEVICE)) (VERBOSE_PREFIX_2 "%s: Setting Device->ButtonConfig '%s' to Pending Delete=1\n", d->id, config->label);
 			config->pendingDelete = 1;
 			config->pendingUpdate = 0;
 		}
@@ -348,9 +349,12 @@ boolean_t sccp_device_check_update(sccp_device_t * device)
 							continue;
 						}
 						if (buttonconfig->pendingDelete) {
-							sccp_log((DEBUGCAT_CONFIG + DEBUGCAT_DEVICE)) (VERBOSE_PREFIX_3 "Remove Buttonconfig for %s from List\n", d->id);
+							sccp_log((DEBUGCAT_CONFIG + DEBUGCAT_DEVICE)) (VERBOSE_PREFIX_3 "%s: Remove Buttonconfig for '%s' from List\n", d->id, buttonconfig->label);
 							SCCP_LIST_REMOVE_CURRENT(list);
 							sccp_free(buttonconfig);
+						} else if (buttonconfig->pendingUpdate) {
+							sccp_log((DEBUGCAT_CONFIG + DEBUGCAT_DEVICE)) (VERBOSE_PREFIX_3 "%s: Buttonconfig '%s' underwent a preplacement\n", d->id, buttonconfig->label);
+							buttonconfig->pendingUpdate = 0;
 						} else {
 							buttonconfig->pendingUpdate = 0;
 						}

--- a/src/sccp_features.c
+++ b/src/sccp_features.c
@@ -6,8 +6,8 @@
  *              See the LICENSE file at the top of the source tree.
  * \since       2009-01-16
  *
- * $Date$
- * $Revision$
+ * $Date: 2015-01-16 20:45:03 +0100 (vr, 16 jan 2015) $
+ * $Revision: 5852 $
  */
 
 /*!
@@ -35,7 +35,7 @@
 #include "sccp_indicate.h"
 #include "sccp_rtp.h"
 
-SCCP_FILE_VERSION(__FILE__, "$Revision$");
+SCCP_FILE_VERSION(__FILE__, "$Revision: 5852 $");
 
 /*!
  * \brief Handle Call Forwarding
@@ -506,7 +506,11 @@ int sccp_feat_grouppickup(sccp_line_t * l, sccp_device_t * d)
 	} else {
 		/* emulate a new call so we end up in the same state as when a new call has been started */
 		sccp_log((DEBUGCAT_CORE)) (VERBOSE_PREFIX_3 "%s: (grouppickup) Starting new channel\n", d->id);
-		c = sccp_channel_newcall(l, d, NULL, SKINNY_CALLTYPE_OUTBOUND, NULL, NULL);
+//		c = sccp_channel_newcall(l, d, NULL, SKINNY_CALLTYPE_OUTBOUND, NULL, NULL);
+		if (!(c = sccp_channel_new_feature_call(l, d, SCCP_FEATURE_PICKUP, NULL, NULL))) {
+		        pbx_log(LOG_ERROR, "%s: (grouppickup) Cannot start a new channel\n", d->id);
+		        return -1;
+		}
 		dest = c->owner;
 	}
 	/* prepare for call pickup */


### PR DESCRIPTION
Split sccp_config_addButton function into two parts (v2)

1) sccp_config_checkButton lauft einfach durch die heutige liste und checkt ob sich was geandert hatt.. Wenn nicht geandert ist werden die pendingDeletes auf 0 gesetzt und sind wir fertig. Gibt es eine anderung dann behalten alle buttonconfig entries deren pendingDelete status Und wird sccp_config_addButton angerufen
2) Dort werden alle buttons (sccp.conf) einfach addiert zu der buttonconfig (wie beim neustart).
3) Nach der reload vorgang schaut post_reload nach ob es noch buttonconfigs gibt mit pendingDelete und nimmt die raus aus der liste.
