### PR TITLE
Socket Handling Enhancements / TCP Keepalive Handling

### DIFF
--- a/src/chan_sccp.c
+++ b/src/chan_sccp.c
@@ -458,6 +458,8 @@ int load_config(void)
 			}
 			ast_verbose(VERBOSE_PREFIX_3 "SCCP channel driver up and running on %s:%d\n", addrStr, sccp_socket_getPort(&GLOB(bindaddr)));
 
+			sccp_socket_setoptions(GLOB(descriptor));
+			
 			if (listen(GLOB(descriptor), DEFAULT_SCCP_BACKLOG)) {
 				pbx_log(LOG_WARNING, "Failed to start listening to %s:%d: %s\n", addrStr, sccp_socket_getPort(&GLOB(bindaddr)), strerror(errno));
 				close(GLOB(descriptor));

--- a/src/sccp_protocol.h
+++ b/src/sccp_protocol.h
@@ -43,7 +43,7 @@
 
 #define DEFAULT_SCCP_PORT				2000							/*!< SCCP uses port 2000. */
 #define DEFAULT_SCCP_SECURE_PORT			2443							/*!< SCCP secure port 2443. */
-#define DEFAULT_SCCP_BACKLOG				2							/*!< the listen baklog. */
+#define DEFAULT_SCCP_BACKLOG				16							/*!< the listen baklog. */
 #define SCCP_MAX_AUTOLOGIN				100							/*!< Maximum allowed of autologins per device */
 #define SCCP_KEEPALIVE					5							/*!< Default keepalive time if not specified in sccp.conf. */
 

--- a/src/sccp_socket.h
+++ b/src/sccp_socket.h
@@ -79,6 +79,7 @@ static inline char *sccp_socket_stringify_port(const struct sockaddr_storage *so
 
 /* end sccp_socket_stringify_fmt short cuts */
 
+void sccp_socket_setoptions(int new_socket);
 void *sccp_socket_thread(void *ignore);
 void sccp_session_sendmsg(const sccp_device_t * device, sccp_mid_t t);
 int sccp_session_send(const sccp_device_t * device, sccp_msg_t * msg);


### PR DESCRIPTION
- move setting of socket options to it's own function for reuse.
- setsockopts before listen() and after accept (required according to spec).
- increased EFAULT_SCCP_BACKLOG from 2 to 16 (linux minimal default).
- move socket related arbitrairy values to the top of the sccp_socket file.
- Add incremental backoff time on read/write retry (adding up to about 9.5 sec before giving up).
- Set SO_LINGER to cleanup immediatly on socket close.
- Set SO_SNDBUF to 5 * max message size
- Set SO_RCVBUF to max message size
- Set SO_KEEPALIVE on
- Set TCP_KEEPALIVE_IDLE=GLOB(keepalive), which should only make TCP-keepalives to be sent once global keepalive has passed
- Set TCP_KEEPALIVE_INTVL=5: Try sending keepalive every 5 seconds
- Set TCP_KEEPALIVE_CNT=5: Try five times before giving up and closing the socket