### PR TITLE
fixes: Error loading module: 'chan_sccp.so' undefined symbol: __use_s…

### DIFF
--- a/src/pbx_impl/ast111/ast111.c
+++ b/src/pbx_impl/ast111/ast111.c
@@ -1176,7 +1176,7 @@ static sccp_parkresult_t sccp_wrapper_asterisk111_park(const sccp_channel_t * ho
 		if (device) {
 			ast_channel_lock(hostChannel->owner);							/* we have to lock our channel, otherwise asterisk crashes internally */
 			if (!ast_masq_park_call(bridgedChannel, hostChannel->owner, 0, &extout)) {
-				sprintf(&extstr[2], sizeof(extstr), " %d", extout);
+				snprintf(&extstr[2], sizeof(extstr), " %d", extout);
 
 				sccp_dev_displayprinotify(device, extstr, 1, 10);
 				sccp_log((DEBUGCAT_CHANNEL | DEBUGCAT_CORE)) (VERBOSE_PREFIX_3 "%s: Parked channel %s on %d\n", DEV_ID_LOG(device), ast_channel_name(bridgedChannel), extout);


### PR DESCRIPTION
fixes: Error loading module: 'chan_sccp.so' undefined symbol: __use_snprintf_instead_of_sprintf__