### PR TITLE
Add missing header to sccp_utils.c

### DIFF
--- a/src/sccp_utils.c
+++ b/src/sccp_utils.c
@@ -10,6 +10,7 @@
  *
  */
 
+#include <locale.h>
 #include "config.h"
 #include "common.h"
 #include "sccp_channel.h"


### PR DESCRIPTION
With newer gcc versions (8.3 tested) compile of sccp_utils.c fails with:

```
    CC       libsccp_la-sccp_utils.lo
  sccp_utils.c: In function 'sccp_utf8_columnwidth':
  sccp_utils.c:1846:2: warning: implicit declaration of function 'setlocale'; did you mean 'ast_setlocale'? [-Wimplicit-function-declaration]
    setlocale(LC_ALL, "");
    ^~~~~~~~~
    ast_setlocale
  sccp_utils.c:1846:12: error: 'LC_ALL' undeclared (first use in this function); did you mean 'AI_ALL'?
    setlocale(LC_ALL, "");
              ^~~~~~
              AI_ALL
  sccp_utils.c:1846:12: note: each undeclared identifier is reported only once for each function it appears in
  Makefile:852: recipe for target 'libsccp_la-sccp_utils.lo' failed
  make[7]: *** [libsccp_la-sccp_utils.lo] Error 1
```

Fix this by adding the missing header.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>

Fixes Issue: Compile fails

Changes proposed by this Pull Request:
- add missing header

Inform: @dkgroot  

Hello Diederik,

In openwrt 2 targets are using gcc 8.3 toolchain already. There chan-sccp fails to build. Full log here: [link](https://downloads.openwrt.org/snapshots/faillogs/arc_archs/telephony/asterisk-chan-sccp/asterisk16/compile.txt) (will be gone soon as I plan to upload the fix to openwrt soon).

Adding the header fixes the build error. Hope I got the order to your liking.

Kind regards,
Seb