### PR TITLE
Don't send invalid XML if there's no name for a parked call

### DIFF
--- a/src/sccp_featureParkingLot.c
+++ b/src/sccp_featureParkingLot.c
@@ -432,7 +432,11 @@ static char * const getParkingLotCXML(sccp_parkinglot_t *pl, int protocolversion
 		for(uint8_t idx = 0; idx < SCCP_VECTOR_SIZE(&pl->slots); idx++) {
 			plslot_t *slot = SCCP_VECTOR_GET_ADDR(&pl->slots, idx);
 			pbx_str_append(&buf, 0, "<MenuItem>");
-			pbx_str_append(&buf, 0, "<Name>%s (%s) by %s</Name>", slot->callerid_name, slot->callerid_num, !sccp_strcaseequals(slot->connectedline_name, "<unknown>") ? slot->connectedline_name : slot->from);
+			if (!sccp_strcaseequals(slot->callerid_name, "<unknown>")) {
+				pbx_str_append(&buf, 0, "<Name>%s (%s) by %s</Name>", slot->callerid_name, slot->callerid_num, !sccp_strcaseequals(slot->connectedline_name, "<unknown>") ? slot->connectedline_name : slot->from);
+			} else {
+				pbx_str_append(&buf, 0, "<Name>%s by %s</Name>", slot->callerid_num, !sccp_strcaseequals(slot->connectedline_name, "<unknown>") ? slot->connectedline_name : slot->from);
+			}
 			pbx_str_append(&buf, 0, "<URL>UserCallData:%d:%d:%d:%d:%s/%s</URL>", appID, instance, 0, transactionId, pl->context, slot->exten);
 			pbx_str_append(&buf, 0, "</MenuItem>");
 		}


### PR DESCRIPTION
When parking outgoing calls the callerid_name can be empty. If that is the case, it would generate invalid xml which the phone rejects.

Inform: @Developers @r00ty-tc
