### PR TITLE
Change depends for package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/chan-sccp/chan-sccp/
 Package: chan-sccp
 Section: libs
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, asterisk (>=11), gettext, libxml2, libxslt1
+Depends: ${shlibs:Depends}, ${misc:Depends}, asterisk (>=11), gettext, libxml2, libxslt1.1
 Recommends: libbinutils, libc6
 Replaces: chan-sccp-b
 Description: chan-sccp is a branch from the original chan-sccp


### PR DESCRIPTION
There is no more libxslt1 package.

Fixes Issue: -

Changes proposed by this Pull Request:
- change depend from libxslt1 to libxslt1.1

Inform: @Developers
