### PR TITLE
HAVE_ICONV Flag was changed to CS_HAVE_ICONV

### DIFF
--- a/configure
+++ b/configure
@@ -24050,7 +24050,7 @@ $as_echo "$am_cv_func_iconv_works" >&6; }
   fi
   if test "$am_func_iconv" = yes; then
 
-$as_echo "#define HAVE_ICONV 1" >>confdefs.h
+$as_echo "#define CS_HAVE_ICONV 1" >>confdefs.h
 
   fi
   if test "$am_cv_lib_iconv" = yes; then


### PR DESCRIPTION
Flag was not changed in configure, so chan-sccp does not recognise that ICONV is installed

Correct configure Flag

Fixes Issue: #574 

Inform: @Developers
