### PR TITLE
Fixed memory leak of thread stack buffer of sccp_session_device_thread

### DIFF
--- a/src/pbx_impl/ast/define.h
+++ b/src/pbx_impl/ast/define.h
@@ -300,6 +300,7 @@ typedef struct pbx_event_sub pbx_event_subscription_t;
 #define pbx_print_group ast_print_group
 #define pbx_print_namedgroup ast_print_namedgroup
 #define pbx_pthread_create ast_pthread_create
+#define pbx_pthread_create_detached ast_pthread_create_detached
 #define pbx_pthread_create_background ast_pthread_create_background
 #define pbx_pthread_create_detached_background ast_pthread_create_detached_background
 #define pbx_pthread_mutex_lock ast_pthread_mutex_lock

--- a/src/sccp_session.c
+++ b/src/sccp_session.c
@@ -734,7 +734,8 @@ gcc_inline void recalc_wait_time(sccp_session_t *s)
  * \callgraph
  * \callergraph
  */
-void *sccp_session_device_thread(void *session)
+void
+*sccp_session_device_thread(void *session)
 {
 	int res = 0;
 	sccp_session_t *s = (sccp_session_t *) session;
@@ -1009,8 +1010,10 @@ static void * accept_thread(void * data)
 		sccp_session_set_ourip(s);
 		sccp_session_addToGlobals(s);
 		recalc_wait_time(s);
-		
-		if (pbx_pthread_create(&s->session_thread, NULL, sccp_session_device_thread, s)) {
+	
+		// Create a detached thread, since the sccp_session_device_thread will not be joined from another thread
+		// Only detached threads free their stack and control structures after termination, otherwise a pthread_join is mandatory for this to take place (davidded).
+		if (pbx_pthread_create_detached(&s->session_thread, NULL, sccp_session_device_thread, s)) {
 			destroy_session(s);
 		}
 	}

--- a/src/sccp_session.c
+++ b/src/sccp_session.c
@@ -734,8 +734,7 @@ gcc_inline void recalc_wait_time(sccp_session_t *s)
  * \callgraph
  * \callergraph
  */
-void
-*sccp_session_device_thread(void *session)
+void *sccp_session_device_thread(void *session)
 {
 	int res = 0;
 	sccp_session_t *s = (sccp_session_t *) session;


### PR DESCRIPTION
I changed the session thread to a detached thread and added the necessary wrapper to the pbx_imp abstraction layer.
The change resolves a difficult to diagnose memory leak which causes monotonic increasing memory usage of asterisk upon repeated TCP connections to chan-sccp (e.g. re-register of phones).

The manpage to pthread_create(3) and pthread_detach(3)  give an explanation why a detached thread is necessary. Only upon pthread_join() the system resources of a pthread are freed after termination of that thread unless the thread is detached. Then the system resources are freed on its own after termination.

The stack is not mentioned explicity in the man pages, which is why I explain the issue in-detail here.
Upon closer look atthe glibc implementation, it is, however, clear that the stack is also retained.

Fixes Issue: #.

Changes proposed by this Pull Request:
- 
- 
- 
- 

Inform: @Developers
