### PR TITLE
Fix use-after-free in sccp_config

### DIFF
--- a/src/sccp_config.c
+++ b/src/sccp_config.c
@@ -3038,10 +3038,12 @@ sccp_config_file_status_t sccp_config_getConfig(boolean_t force, const char * co
 	sccp_log(DEBUGCAT_CORE)(VERBOSE_PREFIX_3 "Config file '%s' loaded.\n", newfilename);
 	res = CONFIG_STATUS_FILE_OK;
 FUNC_EXIT:
-	if (GLOB(config_file_name)) {
-		sccp_free(GLOB(config_file_name));
+	if (newfilename != GLOB(config_file_name)) {
+		if (GLOB(config_file_name)) {
+			sccp_free(GLOB(config_file_name));
+		}
+		GLOB(config_file_name) = pbx_strdup(newfilename);
 	}
-	GLOB(config_file_name) = pbx_strdup(newfilename);
 	return res;
 }
 


### PR DESCRIPTION
On the current build, if the `sccp reload line` command is applied more than once, it will fail with:

```
ERROR[52656]: sccp_config.c:2994 sccp_config_getConfig: Config file '��,��U' not found, aborting (re)load.
```

The characters in the quotes are random and change every time you attempt to re-run the command. The source of this seemed to be a use-after-free under `FUNC_EXIT` in `sccp_config_getConfig`. When reloading a line, `newfilename` points to the same string as `GLOB(config_file_name)`, and the latter is freed and then rewritten with `newfilename` (doing nothing), causing `GLOB(config_file_name)` to point to garbage data.

This patch adds a simple inequality check before the free and strdup.