### PR TITLE
Remove macros

### DIFF
--- a/src/pbx_impl/ast116/ast116.c
+++ b/src/pbx_impl/ast116/ast116.c
@@ -3065,10 +3065,6 @@ DECLARE_PBX_CHANNEL_STRGET(name)
     DECLARE_PBX_CHANNEL_STRGET(linkedid)
     DECLARE_PBX_CHANNEL_STRGET(context)
     DECLARE_PBX_CHANNEL_STRSET(context)
-    DECLARE_PBX_CHANNEL_STRGET(macroexten)
-    DECLARE_PBX_CHANNEL_STRSET(macroexten)
-    DECLARE_PBX_CHANNEL_STRGET(macrocontext)
-    DECLARE_PBX_CHANNEL_STRSET(macrocontext)
     DECLARE_PBX_CHANNEL_STRGET(call_forward)
     DECLARE_PBX_CHANNEL_STRSET(call_forward)
 
@@ -3536,10 +3532,6 @@ const PbxInterface iPbx = {
 	setChannelExten: sccp_astwrap_set_channel_exten,
 	getChannelContext: sccp_astwrap_get_channel_context,
 	setChannelContext: sccp_astwrap_set_channel_context,
-	getChannelMacroExten: sccp_astwrap_get_channel_macroexten,
-	setChannelMacroExten: sccp_astwrap_set_channel_macroexten,
-	getChannelMacroContext: sccp_astwrap_get_channel_macrocontext,
-	setChannelMacroContext: sccp_astwrap_set_channel_macrocontext,
 	getChannelCallForward: sccp_astwrap_get_channel_call_forward,
 	setChannelCallForward: sccp_astwrap_set_channel_call_forward,
 
@@ -3687,10 +3679,6 @@ const PbxInterface iPbx = {
 	.setChannelExten = sccp_astwrap_set_channel_exten,
 	.getChannelContext = sccp_astwrap_get_channel_context,
 	.setChannelContext = sccp_astwrap_set_channel_context,
-	.getChannelMacroExten = sccp_astwrap_get_channel_macroexten,
-	.setChannelMacroExten = sccp_astwrap_set_channel_macroexten,
-	.getChannelMacroContext = sccp_astwrap_get_channel_macrocontext,
-	.setChannelMacroContext = sccp_astwrap_set_channel_macrocontext,
 	.getChannelCallForward = sccp_astwrap_get_channel_call_forward,
 	.setChannelCallForward = sccp_astwrap_set_channel_call_forward,
 


### PR DESCRIPTION
Fixes Issue: #609.

Changes proposed by this Pull Request:
- Remove macro support

The correct answer is probably to create a new `pbx_impl` (or several, seems last is for Asterisk 19) which has this change.
I do not understand `autotools` or this project's build system, so here's my simple solution for building on Asterisk 21+.

Inform: @Developers
